### PR TITLE
fix pip install: ImportError: No module named pip.req:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,22 +2,28 @@ alembic
 MySQL-python
 tooz==1.59
 suds
-napalm==1.1.0
-napalm-base==0.21.0
-napalm-eos==0.5.1
-napalm-fortios==0.3.1
-napalm-ibm==0.1.6
-napalm-ios==0.5.1
-napalm-iosxr==0.4.5
-napalm-junos==0.6.0
-napalm-nxos==0.5.0
-napalm-panos==0.3.0
-napalm-pluribus==0.5.0
+#napalm==1.1.0
+#napalm-base==0.21.0
+#napalm-eos==0.5.1
+#napalm-fortios==0.3.1
+#napalm-ibm==0.1.6
+#napalm-ios==0.5.1
+#napalm-iosxr==0.4.5
+#napalm-junos==0.6.0
+#napalm-nxos==0.5.0
+#napalm-panos==0.3.0
+#napalm-pluribus==0.5.0
 oslo.config==3.14.0
 greenlet==0.4.9
 ipaddr
 paramiko
 
+-e git+https://github.com/noah8713/pip10-nap-1.1.0.git@master#egg=napalm
+-e git+https://github.com/noah8713/pip10-nap-base-0.21.0.git@master#egg=napalm_base
+-e git+https://github.com/noah8713/pip10-nap-eos-0.5.1.git@master#egg=napalm_eos
+-e git+https://github.com/noah8713/pip10-nap-junos-0.6.0.git@master#egg=napalm_junos
+-e git+https://github.com/noah8713/pip10-nap-nxos-0.5.0.git@master#egg=napalm_nxos
 -e git+https://github.com/noah8713/neutron.git@stable/juno#egg=neutron
 -e git+https://github.com/noah8713/ncclient.git@master#egg=ncclient
 pbr==1.10.0
+xmltodict

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,12 @@ install_command =
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
        --editable=git+https://github.com/noah8713/neutron.git@stable/juno#egg=neutron
+       --editable=git+https://github.com/noah8713/pip10-nap-1.1.0.git@master#egg=napalm
+       --editable=git+https://github.com/noah8713/pip10-nap-base-0.21.0.git@master#egg=napalm_base
+       --editable=git+https://github.com/noah8713/pip10-nap-eos-0.5.1.git@master#egg=napalm_eos
+       --editable=git+https://github.com/noah8713/pip10-nap-junos-0.6.0.git@master#egg=napalm_junos
+       --editable=git+https://github.com/noah8713/pip10-nap-nxos-0.5.0.git@master#egg=napalm_nxos
+
 whitelist_externals = sh
 commands =
   dsvm-functional: {toxinidir}/tools/deploy_rootwrap.sh {toxinidir} {envdir}/etc {envdir}/bin


### PR DESCRIPTION
1. Follow steps as per new pip standards https://github.com/capless/warrant/pull/101/files
2. update tox and requirements to use new pinned dependencies.